### PR TITLE
switches variable values to be lazily evaluated

### DIFF
--- a/lib/capistrano/nginx_unicorn/tasks.rb
+++ b/lib/capistrano/nginx_unicorn/tasks.rb
@@ -14,10 +14,10 @@ Capistrano::Configuration.instance.load do
   set_default(:nginx_ssl_certificate_local_path) {Capistrano::CLI.ui.ask "Local path to ssl certificate: "}
   set_default(:nginx_ssl_certificate_key_local_path) {Capistrano::CLI.ui.ask "Local path to ssl certificate key: "}
 
-  set_default(:unicorn_pid, "#{current_path}/tmp/pids/unicorn.pid")
-  set_default(:unicorn_config, "#{shared_path}/config/unicorn.rb")
-  set_default(:unicorn_log, "#{shared_path}/log/unicorn.log")
-  set_default(:unicorn_user, user)
+  set_default(:unicorn_pid) { "#{current_path}/tmp/pids/unicorn.pid" }
+  set_default(:unicorn_config) { "#{shared_path}/config/unicorn.rb" }
+  set_default(:unicorn_log) { "#{shared_path}/log/unicorn.log" }
+  set_default(:unicorn_user) { user }
   set_default(:unicorn_workers) { Capistrano::CLI.ui.ask "Number of unicorn workers: " }
 
   namespace :nginx do


### PR DESCRIPTION
This should make it possible to include this recipe before all the appropriate user/deploy_to variables have been set
