### PR TITLE
Add support for not uploading certificates from local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ set :unicorn_workers, 4
 # default value: false
 set :nginx_use_ssl, false
 
+# if set, it will ask to upload certificates from a local path. Otherwise, it will expect
+# the certificate and key defined in the next 2 variables to be already in the server.
+set :nginx_upload_local_certificate, { true }
+
 # remote file name of the certificate, only makes sense if `nginx_use_ssl` is set
 # default value: `nginx_server_name + ".crt"`
 set :nginx_ssl_certificate, "#{nginx_server_name}.crt"

--- a/lib/capistrano/nginx_unicorn/tasks.rb
+++ b/lib/capistrano/nginx_unicorn/tasks.rb
@@ -11,6 +11,7 @@ Capistrano::Configuration.instance.load do
   set_default(:nginx_use_ssl, false)
   set_default(:nginx_ssl_certificate) { "#{nginx_server_name}.crt" }
   set_default(:nginx_ssl_certificate_key) { "#{nginx_server_name}.key" }
+  set_default(:nginx_upload_local_certificate) { true }
   set_default(:nginx_ssl_certificate_local_path) {Capistrano::CLI.ui.ask "Local path to ssl certificate: "}
   set_default(:nginx_ssl_certificate_key_local_path) {Capistrano::CLI.ui.ask "Local path to ssl certificate key: "}
 
@@ -28,11 +29,13 @@ Capistrano::Configuration.instance.load do
       run "#{sudo} ln -fs /etc/nginx/sites-available/#{application} /etc/nginx/sites-enabled/#{application}"
 
       if nginx_use_ssl
-        put File.read(nginx_ssl_certificate_local_path), "/tmp/#{nginx_ssl_certificate}"
-        put File.read(nginx_ssl_certificate_key_local_path), "/tmp/#{nginx_ssl_certificate_key}"
+        if nginx_upload_local_certificate
+          put File.read(nginx_ssl_certificate_local_path), "/tmp/#{nginx_ssl_certificate}"
+          put File.read(nginx_ssl_certificate_key_local_path), "/tmp/#{nginx_ssl_certificate_key}"
 
-        run "#{sudo} mv /tmp/#{nginx_ssl_certificate} /etc/ssl/certs/#{nginx_ssl_certificate}"
-        run "#{sudo} mv /tmp/#{nginx_ssl_certificate_key} /etc/ssl/private/#{nginx_ssl_certificate_key}"
+          run "#{sudo} mv /tmp/#{nginx_ssl_certificate} /etc/ssl/certs/#{nginx_ssl_certificate}"
+          run "#{sudo} mv /tmp/#{nginx_ssl_certificate_key} /etc/ssl/private/#{nginx_ssl_certificate_key}"
+        end
 
         run "#{sudo} chown root:root /etc/ssl/certs/#{nginx_ssl_certificate}"
         run "#{sudo} chown root:root /etc/ssl/private/#{nginx_ssl_certificate_key}"


### PR DESCRIPTION
This will allow a user that doesn't want to keep certificates in his personal computers and want to rely on other tools like Chef with encrypted data bags, not to be asked for it.
