### PR TITLE
Added custon nginx configuration path support

### DIFF
--- a/lib/capistrano/nginx_unicorn/tasks.rb
+++ b/lib/capistrano/nginx_unicorn/tasks.rb
@@ -20,13 +20,19 @@ Capistrano::Configuration.instance.load do
   set_default(:unicorn_log) { "#{shared_path}/log/unicorn.log" }
   set_default(:unicorn_user) { user }
   set_default(:unicorn_workers) { Capistrano::CLI.ui.ask "Number of unicorn workers: " }
+  
+  set_default(:nginx_config_path) { "/etc/nginx/sites-available" }
 
   namespace :nginx do
     desc "Setup nginx configuration for this application"
     task :setup, roles: :web do
       template("nginx_conf.erb", "/tmp/#{application}")
-      run "#{sudo} mv /tmp/#{application} /etc/nginx/sites-available/#{application}"
-      run "#{sudo} ln -fs /etc/nginx/sites-available/#{application} /etc/nginx/sites-enabled/#{application}"
+      if nginx_config_path == "/etc/nginx/sites-available"
+          run "#{sudo} mv /tmp/#{application} /etc/nginx/sites-available/#{application}"
+          run "#{sudo} ln -fs /etc/nginx/sites-available/#{application} /etc/nginx/sites-enabled/#{application}"
+      else
+          run "#{sudo} mv /tmp/#{application} #{nginx_config_path}/#{application}.conf"
+      end
 
       if nginx_use_ssl
         if nginx_upload_local_certificate


### PR DESCRIPTION
Added some customization for Nginx configs path 'cause not all OS and admins use the available&enabled pattern, some prefer the old-school /etc/nginx/vhosts/*.conf style or something else. Thought it might come in handy.
