### PR TITLE
Adds NginX pid file path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ set :nginx_server_name, "example.com"
 # default value: `"#{current_path}/tmp/pids/unicorn.pid"`
 set :unicorn_pid, "#{current_path}/tmp/pids/unicorn.pid"
 
+# path, where nginx pid file will be stored (used in logrotate recipe)
+# default value: `"/run/nginx.pid"`
+set :nginx_pid, "/run/nginx.pid"
+
 # path, where unicorn config file will be stored
 # default value: `"#{shared_path}/config/unicorn.rb"`
 set :unicorn_config, "#{shared_path}/config/unicorn.rb"

--- a/lib/capistrano/nginx_unicorn/tasks.rb
+++ b/lib/capistrano/nginx_unicorn/tasks.rb
@@ -9,6 +9,7 @@ Capistrano::Configuration.instance.load do
 
   set_default(:nginx_server_name) { Capistrano::CLI.ui.ask "Nginx server name: " }
   set_default(:nginx_use_ssl, false)
+  set_default(:nginx_pid) { "/run/nginx.pid" }
   set_default(:nginx_ssl_certificate) { "#{nginx_server_name}.crt" }
   set_default(:nginx_ssl_certificate_key) { "#{nginx_server_name}.key" }
   set_default(:nginx_upload_local_certificate) { true }

--- a/lib/generators/capistrano/nginx_unicorn/templates/logrotate.erb
+++ b/lib/generators/capistrano/nginx_unicorn/templates/logrotate.erb
@@ -18,6 +18,7 @@
   endscript
 
   postrotate
-    [ ! -f /run/nginx.pid ] || kill -USR1 `cat /run/nginx.pid`
+    nginx_pid=<%= nginx_pid %>
+    [ ! -f $nginx_pid ] || kill -USR1 `cat $nginx_pid`
   endscript
 }


### PR DESCRIPTION
I added an option to change the path to the nginx.pid file by setting a variable named nginx_pid.
The default is still "/run/nginx.pid" but on some OS, NginX pid file is not located on /run/nginx.pid.
