### PR TITLE
nginx_pid is in a different location on centos

### DIFF
--- a/lib/capistrano/nginx_unicorn/tasks.rb
+++ b/lib/capistrano/nginx_unicorn/tasks.rb
@@ -9,7 +9,7 @@ Capistrano::Configuration.instance.load do
 
   set_default(:nginx_server_name) { Capistrano::CLI.ui.ask "Nginx server name: " }
   set_default(:nginx_use_ssl, false)
-  set_default(:nginx_pid) { "/run/nginx.pid" }
+  set_default(:nginx_pid) { "/var/run/nginx.pid" }
   set_default(:nginx_ssl_certificate) { "#{nginx_server_name}.crt" }
   set_default(:nginx_ssl_certificate_key) { "#{nginx_server_name}.key" }
   set_default(:nginx_upload_local_certificate) { true }


### PR DESCRIPTION
updates the default for the centos branch
