### PR TITLE
fix unicorn_pid default value typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ set :nginx_ssl_certificate_key, "#{nginx_server_name}.key"
 set :nginx_config_path, "/etc/nginx/sites-available"
 
 # path, where unicorn pid file will be stored
-# default value: `"#{current_path}/tmp/pids/unicorn.pid"`
-set :unicorn_pid, "#{current_path}/tmp/pids/unicorn.pid"
+# default value: `"#{shared_path}/pids/unicorn.pid"`
+set :unicorn_pid, "#{shared_path}/pids/unicorn.pid"
 
 # path, where unicorn config file will be stored
 # default value: `"#{shared_path}/config/unicorn.rb"`


### PR DESCRIPTION
I found that there's a typo in README.md file, which specify unicorn_pid default value to be inside tmp folder, but actually, It should be in {shared_path}/pids folder
