### PR TITLE
Make nginx listen ports configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ set :nginx_server_name, "example.com"
 set :nginx_pid, "/run/nginx.pid"
 
 # if set, nginx will be configured to 443 port and port 80 will be auto rewritten to 443
+# set `nginx_http_port` and `nginx_https_port` if you need to change these ports
 # also, on `nginx:setup`, paths to ssl certificate and key will be configured
 # and certificate file and key will be copied to `/etc/ssl/certs` and `/etc/ssl/private/` directories
-# default value: false
+# default value: false.
 set :nginx_use_ssl, false
 
 # if set, it will ask to upload certificates from a local path. Otherwise, it will expect
@@ -116,6 +117,12 @@ set :nginx_ssl_certificate_key, "#{nginx_server_name}.key"
 # centos users can set `/etc/nginx/conf.d`
 # default value: `/etc/nginx/sites-available`
 set :nginx_config_path, "/etc/nginx/sites-available"
+
+# nginx http listen port
+set :nginx_http_port, 80
+
+# nginx https listen port
+set :nginx_http_port, 443
 
 # path, where unicorn pid file will be stored
 # default value: `"#{current_path}/tmp/pids/unicorn.pid"`

--- a/lib/capistrano/nginx_unicorn/defaults.rb
+++ b/lib/capistrano/nginx_unicorn/defaults.rb
@@ -9,6 +9,8 @@ set :nginx_upload_local_certificate, true
 set :nginx_ssl_certificate_local_path, -> { ask(:nginx_ssl_certificate_local_path, "Local path to ssl certificate: ") }
 set :nginx_ssl_certificate_key_local_path, -> { ask(:nginx_ssl_certificate_key_local_path, "Local path to ssl certificate key: ") }
 set :nginx_config_path, "/etc/nginx/sites-available"
+set :nginx_http_port, 80
+set :nginx_https_port, 443
 
 set :unicorn_service_name, -> { "unicorn_#{fetch(:application)}_#{fetch(:stage)}" }
 set :unicorn_pid, -> { shared_path.join("pids/unicorn.pid") }

--- a/lib/generators/capistrano/nginx_unicorn/templates/nginx_conf.erb
+++ b/lib/generators/capistrano/nginx_unicorn/templates/nginx_conf.erb
@@ -11,12 +11,12 @@ server {
 
 server {
 <% if fetch(:nginx_use_ssl) %>
-  listen 443;
+  listen <%= fetch(:nginx_https_port) %>;
   ssl on;
   ssl_certificate /etc/ssl/certs/<%= fetch(:nginx_ssl_certificate) %>;
   ssl_certificate_key /etc/ssl/private/<%= fetch(:nginx_ssl_certificate_key) %>;
 <% else %>
-  listen 80;
+  listen <%= fetch(:nginx_http_port) %>;
 <% end %>
 
   client_max_body_size 4G;


### PR DESCRIPTION
Made `nginx` ports configurable from `deploy.rb` config without the need to customize the templates.

Also updated the related README section
