### PR TITLE
Added Rbenv support for unicorn

### DIFF
--- a/lib/generators/capistrano/nginx_unicorn/templates/unicorn_init.erb
+++ b/lib/generators/capistrano/nginx_unicorn/templates/unicorn_init.erb
@@ -21,8 +21,8 @@ CMD="cd $APP_ROOT; bundle exec unicorn -D -c <%= fetch(:unicorn_config) %> -E <%
 # rvm
 #CMD="cd <%= current_path %>; <%= fetch(:rvm_path) %>/bin/rvm do bundle exec unicorn -D -c <%= fetch(:unicorn_config) %> -E <%= fetch(:rails_env) %>"
 
-# rbenv TODO
-# doesn't work CMD="cd <%= current_path %>; bundle exec unicorn -D -c <%= fetch(:unicorn_config) %> -E <%= fetch(:rails_env) %>"
+# Rbenv
+# CMD="cd <%= current_path %>; <%= fetch(:rbenv_path) %>/bin/rbenv exec bundle exec unicorn -D -c <%= fetch(:unicorn_config) %> -E <%= fetch(:rails_env) %>"
 
 AS_USER=<%= fetch(:unicorn_user) %>
 set -u


### PR DESCRIPTION
## Summary

Added [Rbenv](https://github.com/sstephenson/rbenv) to Unicorn Template
## Notes

I used the following Rbenv gems for capistrano 3
- https://github.com/capistrano/rbenv
- https://github.com/capistrano-plugins/capistrano-rbenv-install
